### PR TITLE
Fix circular JSON structure error in cart service

### DIFF
--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -64,7 +64,6 @@ export class CartService {
 
   private save() {
     const payload = { version: 1, items: this.items, savedAt: Date.now() };
-    this.items.forEach((c: any) => (c._meta = payload));
     localStorage.setItem('bb-cart', JSON.stringify(payload));
   }
 


### PR DESCRIPTION
## Summary

- Fixed TypeError: Converting circular structure to JSON crash in CartService
- Removed unnecessary _meta property assignment that created circular references
- Cart items can now be added successfully without JSON serialization errors
- Issue occurred when users confirmed selections in customizer modal

## Changes

- `src/app/services/cart.service.ts`: Removed line that assigned _meta property pointing back to payload object, eliminating circular reference in save() method

Fixes #17

Fixes #17