### PR TITLE
Fix circular reference crash in cart save operation

### DIFF
--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -64,7 +64,6 @@ export class CartService {
 
   private save() {
     const payload = { version: 1, items: this.items, savedAt: Date.now() };
-    this.items.forEach((c: any) => (c._meta = payload));
     localStorage.setItem('bb-cart', JSON.stringify(payload));
   }
 


### PR DESCRIPTION
## Summary

- Fixed TypeError: Converting circular structure to JSON in CartService.save()
- Removed problematic _meta property assignment that created circular references
- Cart save operations now complete successfully when users confirm orders
- Eliminated crash that occurred every time customizer modal was completed

## Changes

- `src/app/services/cart.service.ts`: Removed line that assigned _meta property to cart items, preventing circular reference chain that caused JSON.stringify to throw TypeError

Fixes #19

Fixes #19