### PR TITLE
Fix circular structure JSON error in cart service

### DIFF
--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -64,14 +64,16 @@ export class CartService {
 
   private save() {
     const payload = { version: 1, items: this.items, savedAt: Date.now() };
-    this.items.forEach((c: any) => (c._meta = payload));
     localStorage.setItem('bb-cart', JSON.stringify(payload));
   }
 
   private load() {
     try {
       const saved = localStorage.getItem('bb-cart');
-      if (saved) this.items = JSON.parse(saved);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        this.items = (parsed.items ?? []).map(({ item, quantity, size, milk, extras, unitPrice }: CartItem) => ({ item, quantity, size, milk, extras, unitPrice }));
+      }
     } catch { /* ignore corrupt data */ }
   }
 }


### PR DESCRIPTION
## Summary

- Fixed TypeError: Converting circular structure to JSON in CartService.save()
- Removed line that created circular _meta back-references on CartItem objects
- Added cleanup logic to filter out corrupted properties from existing localStorage entries
- Issue occurred when users added items to cart after customizing options

## Changes

- `src/app/services/cart.service.ts`: Removed circular reference creation in save() method and improved load() method to filter unwanted properties

Fixes #24