### PR TITLE
Fix circular JSON reference error in CartService save method

### DIFF
--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -64,7 +64,6 @@ export class CartService {
 
   private save() {
     const payload = { version: 1, items: this.items, savedAt: Date.now() };
-    this.items.forEach((c: any) => (c._meta = payload));
     localStorage.setItem('bb-cart', JSON.stringify(payload));
   }
 


### PR DESCRIPTION
## Summary

- Fixes TypeError "Converting circular structure to JSON" occurring when users add items to cart
- Removes unnecessary `_meta` property assignment that created circular references
- Resolves crash when `CartService.save()` attempts to serialize cart data to localStorage
- Triggered during cart item customization flow when user confirms selections

## Changes

- `src/app/services/cart.service.ts`: Removed forEach loop that assigned circular `_meta` references to cart items

Fixes #26