### PR TITLE
[AI][Sentinel] SENTINEL-GUINEA-PIG-5 - Fix null pointer in MenuCardComponent rating

### DIFF
--- a/src/app/components/menu-card/menu-card.component.ts
+++ b/src/app/components/menu-card/menu-card.component.ts
@@ -33,7 +33,7 @@ export class MenuCardComponent implements OnInit {
   }
 
   rate(stars: number) {
-    const data: any = JSON.parse(localStorage.getItem(this.storageKey) as string);
+    const data: any = JSON.parse(localStorage.getItem(this.storageKey) || '{}');
     if (!data[this.item.name]) data[this.item.name] = { total: 0, count: 0 };
     data[this.item.name].total += stars;
     data[this.item.name].count++;


### PR DESCRIPTION
## Summary

- Fixed TypeError when first-time users attempt to rate menu items
- Added null-safety fallback pattern consistent with existing loadRating() method
- Prevents crash when localStorage returns null for unset 'bb-ratings' key
- Ensures rating functionality works properly for new users

## Changes

- `src/app/components/menu-card/menu-card.component.ts`: Added `|| "{}"` fallback to JSON.parse call in rate() method to handle null localStorage values

Fixes #37